### PR TITLE
Support for Reporter format 'ux'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Gradle plugin for the requirement tracing suite [OpenFastTrace](https://github.c
 
     ```groovy
     plugins {
-      id "org.itsallcode.openfasttrace" version "3.0.1"
+      id "org.itsallcode.openfasttrace" version "3.2.0"
     }
     ```
 
@@ -50,10 +50,12 @@ You can configure the following properties:
 
 * `failBuild`: Fail build when tracing finds any issues (default: `true`)
 * `inputDirectories`: Files or directories to import
-* `reportFile`: Path to the report file
+* `reportFile`: Path to the report file (do not specify when using the `ux` `reportFormat`)
 * `reportFormat`: Format of the report
   * `plain` - Plain Text (default)
   * `html` - HTML
+  * `aspec` - Extended requirement.xml format
+  * `ux` - HTML based requirement browser
 * `reportVerbosity`: Report verbosity
   * `quiet` - no output (in case only the return code is used)
   * `minimal` - display ok or not ok

--- a/build.gradle
+++ b/build.gradle
@@ -10,17 +10,21 @@ plugins {
 }
 
 repositories {
+    if (!gradle.startParameter.taskNames.contains("publish")) {
+        mavenLocal()
+    }
     mavenCentral()
 }
 
 apply from: 'gradle/workAroundJacocoGradleTestKitIssueOnWindows.gradle'
 
-version = '3.0.1'
+version = '3.2.0'
 group = 'org.itsallcode'
 
 ext {
     gradlePluginId = 'org.itsallcode.openfasttrace'
-    oftVersion = '4.1.0'
+    oftVersion = '4.2.0'
+    uxVersion = '0.1.0'
     junitVersion = '5.11.0'
     if (project.hasProperty('oftSourceDir')) {
         oftSourceDir = file(project.oftSourceDir)
@@ -93,6 +97,45 @@ task compileOft(type: Exec) {
          '-Djava.version=' + getJavaVersion()
 }
 
+// >> openfasttrace-ux
+
+
+ext {
+    if (project.hasProperty('uxSourceDir')) {
+        uxSourceDir = file(project.uxSourceDir)
+    } else {
+        uxSourceDir = 'oft-dir-not-found'
+    }
+}
+
+tasks.register("compileUx", Exec) {
+    workingDir uxSourceDir
+
+    commandLine 'npm', 'run', 'deploy'
+}
+compileUx.onlyIf { project.file(uxSourceDir).isDirectory() }
+
+configurations {
+    create("openfasttraceux")
+}
+dependencies {
+    openfasttraceux "org.itsallcode:openfasttrace-ux:$uxVersion"
+}
+
+task addOftUxAsResource(type: Copy) {
+    description "Adds the OpenFastTrace-UX ZIP artifact as file resources to the gradle plugin"
+    dependsOn(compileUx)
+
+    from configurations.getByName("openfasttraceux").getSingleFile()
+    into layout.buildDirectory.dir("resources/main")
+    rename { "openfasttrace-ux.zip" }
+}
+tasks.named("processResources") {
+    dependsOn("addOftUxAsResource")
+}
+
+// << openfasttrace-ux
+
 clean {
     def exampleProjects = rootProject.file('example-projects').listFiles()
     def propertyFiles = exampleProjects.collect { new File(it, 'gradle.properties') }
@@ -117,6 +160,9 @@ signing {
     def signingKey = findProperty("signingKey")
     def signingPassword = findProperty("signingPassword")
     useInMemoryPgpKeys(signingKey, signingPassword)
+}
+tasks.withType(Sign) {
+    onlyIf { !gradle.startParameter.taskNames.contains("publishToMavenLocal") }
 }
 
 testing {

--- a/example-projects/ux-report/build.gradle
+++ b/example-projects/ux-report/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id "base"
+    id 'org.itsallcode.openfasttrace' version '3.2.0'
+}
+
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+requirementTracing {
+    failBuild = false
+    if (project.hasProperty('oftSourceDir')) {
+        oftSourceDir = file(project.oftSourceDir)
+        if (!oftSourceDir.exists()) {
+            logger.warn "OFT source directory $oftSourceDir does not exist"
+        }
+        inputDirectories = files(
+                "$oftSourceDir/doc/spec",
+                "$oftSourceDir/api/src/main",
+                "$oftSourceDir/core/src/main",
+                "$oftSourceDir/exporter/**/src/main",
+                "$oftSourceDir/importer/**/src/main",
+                "'$oftSourceDir/reporter/**/src/main"
+        )
+    } else {
+        inputDirectories = files('custom-dir')
+    }
+    reportFormat = 'ux'
+}

--- a/example-projects/ux-report/custom-dir/source.java
+++ b/example-projects/ux-report/custom-dir/source.java
@@ -1,0 +1,1 @@
+// [impl->dsn~exampleB~1]

--- a/example-projects/ux-report/custom-dir/spec.md
+++ b/example-projects/ux-report/custom-dir/spec.md
@@ -1,0 +1,7 @@
+# Tracing Example
+
+`dsn~exampleB~1`
+
+Example requirement
+
+Needs: utest, impl

--- a/example-projects/ux-report/settings.gradle
+++ b/example-projects/ux-report/settings.gradle
@@ -1,0 +1,6 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}

--- a/src/main/java/org/itsallcode/openfasttrace/gradle/OpenFastTracePlugin.java
+++ b/src/main/java/org/itsallcode/openfasttrace/gradle/OpenFastTracePlugin.java
@@ -1,12 +1,5 @@
 package org.itsallcode.openfasttrace.gradle;
 
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
-
-import java.io.File;
-import java.util.*;
-import java.util.stream.Stream;
-
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -19,6 +12,16 @@ import org.itsallcode.openfasttrace.gradle.task.CollectTask;
 import org.itsallcode.openfasttrace.gradle.task.TraceTask;
 import org.itsallcode.openfasttrace.gradle.task.config.SerializableTagPathConfig;
 import org.slf4j.Logger;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 public class OpenFastTracePlugin implements Plugin<Project>
 {
@@ -79,17 +82,7 @@ public class OpenFastTracePlugin implements Plugin<Project>
         final TracingConfig config = getConfig(rootProject);
         task.getFailBuild().set(config.getFailBuild());
         task.getRequirementsFile().set(collectTask.get().getOutputFile());
-        if (config.getReportFile().isPresent())
-        {
-            task.getOutputFile().set(config.getReportFile());
-        }
-        else
-        {
-            final String extension = "html".equals(config.getReportFormat().get()) ? "html" : "txt";
-            task.getOutputFile()
-                    .set(new File(rootProject.getLayout().getBuildDirectory().getAsFile().get(),
-                            "reports/tracing." + extension));
-        }
+        configureOutputs(rootProject, task, config);
         task.getReportVerbosity().set(config.getReportVerbosity());
         task.getReportFormat().set(config.getReportFormat());
         task.getImportedRequirements().set(getImportedRequirements(rootProject.getAllprojects()));
@@ -97,6 +90,39 @@ public class OpenFastTracePlugin implements Plugin<Project>
         task.getFilteredTags().set(config.getFilteredTags());
         task.getFilterAcceptsItemsWithoutTag().set(config.getFilterAcceptsItemsWithoutTag());
         task.getDetailsSectionDisplay().set(config.getDetailsSectionDisplay());
+    }
+
+    private static void configureOutputs( final Project rootProject,
+                                          final TraceTask task,
+                                          final TracingConfig config )
+    {
+        if( config.getReportFile().isPresent() )
+        {
+            task.getOutputFile().set( config.getReportFile() );
+        }
+        else
+        {
+            final String reporterFormat = config.getReportFormat().get();
+            task.getOutputFile()
+                    .set( new File( rootProject.getLayout().getBuildDirectory().getAsFile().get(),
+                            toReporterFile( reporterFormat ) ) );
+            final String resourceName = "openfasttrace-" + reporterFormat + ".zip";
+            final URL resource = task.getClass().getClassLoader().getResource( resourceName );
+            if( "ux".equals( reporterFormat ) )
+            {
+                task.getReportFile().set( "build/reports/openfasttrace/html/openfasttrace.html" );
+            }
+            if( resource != null )
+                task.getAdditionalResources().add( resourceName );
+        }
+    }
+
+    private static String toReporterFile( final String reporterFormat )
+    {
+        return "ux".equals( reporterFormat ) ? "reports/openfasttrace/resources/js/specitem_data.js"
+                : "html".equals( reporterFormat ) ? "reports/tracing.html"
+                : "reports/tracing.txt";
+
     }
 
     private static Set<File> getAllInputDirectories(final Set<Project> allProjects)

--- a/src/test/java/org/itsallcode/openfasttrace/gradle/OpenFastTracePluginTest.java
+++ b/src/test/java/org/itsallcode/openfasttrace/gradle/OpenFastTracePluginTest.java
@@ -1,25 +1,33 @@
 package org.itsallcode.openfasttrace.gradle;
 
+import org.gradle.api.logging.Logging;
+import org.gradle.internal.impldep.org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.gradle.internal.impldep.org.apache.commons.compress.archivers.zip.ZipFile;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.gradle.testkit.runner.UnexpectedBuildFailure;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.joining;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-
-import java.io.*;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.*;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.gradle.api.logging.Logging;
-import org.gradle.internal.impldep.org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
-import org.gradle.internal.impldep.org.apache.commons.compress.archivers.zip.ZipFile;
-import org.gradle.testkit.runner.*;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
-import org.slf4j.Logger;
 
 class OpenFastTracePluginTest
 {
@@ -33,6 +41,7 @@ class OpenFastTracePluginTest
     private static final Path DEPENDENCY_CONFIG_DIR = EXAMPLES_DIR.resolve("dependency-config");
     private static final Path PUBLISH_CONFIG_DIR = EXAMPLES_DIR.resolve("publish-config");
     private static final Path HTML_REPORT_CONFIG_DIR = EXAMPLES_DIR.resolve("html-report");
+    private static final Path UX_REPORT_CONFIG_DIR = EXAMPLES_DIR.resolve("ux-report");
 
     @ParameterizedTest(name = "testTracingTaskAddedToProject {0}")
     @EnumSource
@@ -140,6 +149,15 @@ class OpenFastTracePluginTest
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":traceRequirements").getOutcome());
         buildResult = runBuild(config, HTML_REPORT_CONFIG_DIR, "traceRequirements");
         assertEquals(TaskOutcome.UP_TO_DATE, buildResult.task(":traceRequirements").getOutcome());
+    }
+
+    @ParameterizedTest(name = "testUxReporter {0}")
+    @EnumSource
+    void testUxReporter(final GradleTestConfig config)
+    {
+        BuildResult buildResult = runBuild(config , UX_REPORT_CONFIG_DIR, "clean",
+                "traceRequirements");
+        assertEquals(TaskOutcome.SUCCESS, buildResult.task(":traceRequirements").getOutcome());
     }
 
     @ParameterizedTest(name = "testTraceExampleProjectWithCustomConfig {0}")
@@ -318,10 +336,10 @@ class OpenFastTracePluginTest
             allArgs.addAll(asList("--warning-mode", "all"));
         }
         final GradleRunner runner = GradleRunner.create() //
-                .withProjectDir(projectDir.toFile()) //
-                .withPluginClasspath() //
-                .withArguments(allArgs) //
-                .forwardOutput();
+                                                .withProjectDir(projectDir.toFile()) //
+                                                .withPluginClasspath() //
+                                                .withArguments(allArgs) //
+                                                .forwardOutput();
         if (config.gradleVersion != null)
         {
             runner.withGradleVersion(config.gradleVersion);


### PR DESCRIPTION
The 'ux' reporter generates the tracing report for the requirement browser [OpenFastTrace UX](https://github.com/poldi2015/openfasttrace-ux). The Gradle support generates a locally executable browser frontent for the current requirement tracing project,